### PR TITLE
Fix patch file so composer install succeeds applying it

### DIFF
--- a/patches/social_auth_github.patch
+++ b/patches/social_auth_github.patch
@@ -1,6 +1,6 @@
-diff -ur web/modules/contrib/social_auth_github/src/GitHubAuthManager.php web/modules/contrib/social_auth_github.patched/src/GitHubAuthManager.php
---- web/modules/contrib/social_auth_github/src/GitHubAuthManager.php	2022-07-15 11:25:25.000000000 -0400
-+++ web/modules/contrib/social_auth_github.patched/src/GitHubAuthManager.php	2024-06-17 13:17:50.802129383 -0400
+diff -ur a/src/GitHubAuthManager.php b/src/GitHubAuthManager.php
+--- a/src/GitHubAuthManager.php	2022-07-15 11:25:25.000000000 -0400
++++ b/src/GitHubAuthManager.php	2024-06-17 13:17:50.802129383 -0400
 @@ -4,11 +4,13 @@
  
  use Drupal\Core\Config\ConfigFactory;


### PR DESCRIPTION
`composer install` fails with:
```
  - Applying patches for drupal/social_auth_github
    patches/social_auth_github.patch (Github cancel login fix)
   Could not apply patch! Skipping. The error was: The process "patch '-p1' --no-backup-if-mismatch -d 'web/modules/contrib/social_auth_github' < 'patches/social_auth_github.patch'" exceeded the timeout of 300 seconds.

```
This change fixes that problem.
