### PR TITLE
Improved items per page handling

### DIFF
--- a/web/modules/mof/src/Controller/ModelController.php
+++ b/web/modules/mof/src/Controller/ModelController.php
@@ -134,7 +134,7 @@ final class ModelController extends ControllerBase {
   /**
    * List model collection for admins.
    */
-  public function collection(): array {
+  public function collection(): array|RedirectResponse {
     return $this->entityTypeManager()->getHandler('model', 'admin_list_builder')->render();
   }
 

--- a/web/modules/mof/src/LicenseListBuilder.php
+++ b/web/modules/mof/src/LicenseListBuilder.php
@@ -71,19 +71,5 @@ final class LicenseListBuilder extends EntityListBuilder {
     return ($url = $this->getPageRedirectUrl()) != NULL ? $this->redirectPage($url) : parent::render();
   }
 
-  /**
-   * Count of total license entites.
-   *
-   * @return int Number of license entities.
-   */
-  protected function getEntityCount(): int {
-    return $this
-      ->getStorage()
-      ->getQuery()
-      ->accessCheck(TRUE)
-      ->count()
-      ->execute();
-  }
-
 }
 

--- a/web/modules/mof/src/LicenseListBuilder.php
+++ b/web/modules/mof/src/LicenseListBuilder.php
@@ -7,6 +7,7 @@ namespace Drupal\mof;
 use Drupal\Core\Entity\EntityListBuilder;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\Query\QueryInterface;
+use Symfony\Component\HttpFoundation\RedirectResponse;
 
 /**
  * Provides a list controller for the license entity type.
@@ -62,5 +63,27 @@ final class LicenseListBuilder extends EntityListBuilder {
 
     return $query;
   }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function render(): array|RedirectResponse {
+    return ($url = $this->getPageRedirectUrl()) != NULL ? $this->redirectPage($url) : parent::render();
+  }
+
+  /**
+   * Count of total license entites.
+   *
+   * @return int Number of license entities.
+   */
+  protected function getEntityCount(): int {
+    return $this
+      ->getStorage()
+      ->getQuery()
+      ->accessCheck(TRUE)
+      ->count()
+      ->execute();
+  }
+
 }
 

--- a/web/modules/mof/src/ModelAdminListBuilder.php
+++ b/web/modules/mof/src/ModelAdminListBuilder.php
@@ -102,18 +102,4 @@ class ModelAdminListBuilder extends EntityListBuilder {
     return ($url = $this->getPageRedirectUrl()) != NULL ? $this->redirectPage($url) : parent::render();
   }
 
-  /**
-   * Count of total model entites.
-   *
-   * @return int Number of model entities.
-   */
-  protected function getEntityCount(): int {
-    return $this
-      ->getStorage()
-      ->getQuery()
-      ->accessCheck(TRUE)
-      ->count()
-      ->execute();
-  }
-
 }

--- a/web/modules/mof/src/ModelAdminListBuilder.php
+++ b/web/modules/mof/src/ModelAdminListBuilder.php
@@ -9,6 +9,7 @@ use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\Query\QueryInterface;
 use Drupal\Core\Url;
 use Drupal\mof\Entity\Model;
+use Symfony\Component\HttpFoundation\RedirectResponse;
 
 class ModelAdminListBuilder extends EntityListBuilder {
 
@@ -92,6 +93,27 @@ class ModelAdminListBuilder extends EntityListBuilder {
       'updated' => ['data' => $entity->get('changed')->view(['label' => 'hidden'])],
       'approver' => $entity->getApprover() ? $entity->getApprover()->getDisplayName() : '',
     ] + parent::buildRow($entity);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function render(): array|RedirectResponse {
+    return ($url = $this->getPageRedirectUrl()) != NULL ? $this->redirectPage($url) : parent::render();
+  }
+
+  /**
+   * Count of total model entites.
+   *
+   * @return int Number of model entities.
+   */
+  protected function getEntityCount(): int {
+    return $this
+      ->getStorage()
+      ->getQuery()
+      ->accessCheck(TRUE)
+      ->count()
+      ->execute();
   }
 
 }

--- a/web/modules/mof/src/ModelListBuilder.php
+++ b/web/modules/mof/src/ModelListBuilder.php
@@ -10,9 +10,11 @@ use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\EntityListBuilder;
 use Drupal\Core\Entity\Query\QueryInterface;
 use Drupal\Core\Form\FormBuilderInterface;
+use Drupal\Core\Url;
 use Drupal\mof\Entity\Model;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RedirectResponse;
 
 /**
  * Provides a list controller for the model entity type.
@@ -62,7 +64,11 @@ final class ModelListBuilder extends EntityListBuilder {
   /**
    * {@inheritdoc}
    */
-  public function render(): array {
+  public function render(): array|RedirectResponse {
+    if (($url = $this->getPageRedirectUrl()) !== NULL) {
+      return $this->redirectPage($url);
+    }
+
     $build = parent::render();
     $build['#attached']['library'][] = 'mof/model-list';
     $build['search'] = $this->formBuilder->getForm('\Drupal\mof\Form\ModelSearchForm');
@@ -70,6 +76,7 @@ final class ModelListBuilder extends EntityListBuilder {
     $build['table']['#attributes']['class'][] = 'tablesaw';
     $build['table']['#attributes']['class'][] = 'tablesaw-stack';
     $build['table']['#attributes']['data-tablesaw-mode'] = 'stack';
+
     return $build;
   }
 
@@ -182,6 +189,20 @@ final class ModelListBuilder extends EntityListBuilder {
     }
 
     return $query;
+  }
+
+  /**
+   * Count of total model entites.
+   *
+   * @return int Number of model entities.
+   */
+  protected function getEntityCount(): int {
+    return $this
+      ->getStorage()
+      ->getQuery()
+      ->accessCheck(TRUE)
+      ->count()
+      ->execute();
   }
 
 }

--- a/web/modules/mof/src/ModelListBuilder.php
+++ b/web/modules/mof/src/ModelListBuilder.php
@@ -191,18 +191,4 @@ final class ModelListBuilder extends EntityListBuilder {
     return $query;
   }
 
-  /**
-   * Count of total model entites.
-   *
-   * @return int Number of model entities.
-   */
-  protected function getEntityCount(): int {
-    return $this
-      ->getStorage()
-      ->getQuery()
-      ->accessCheck(TRUE)
-      ->count()
-      ->execute();
-  }
-
 }

--- a/web/modules/mof/src/PageLimitTrait.php
+++ b/web/modules/mof/src/PageLimitTrait.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Drupal\mof;
 
+use Drupal\Core\Url;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+
 trait PageLimitTrait {
 
   /**
@@ -14,6 +17,44 @@ trait PageLimitTrait {
     if (($limit = $request->get('limit')) !== NULL && intval($limit) > 0) {
       $this->limit = $limit;
     }
+  }
+
+  /**
+   * Returns a Url with new page number if there are not enough
+   * entities to display on the current page. Returns NULL otherwise.
+   *
+   * @throws \Exception If parent class doesn't implement getEntityCount().
+   * @return \Drupal\Core\Url|null
+   */
+  public function getPageRedirectUrl(): ?Url {
+    if (!method_exists($this, 'getEntityCount')) {
+      throw new \Exception('getEntityCount() method does not exist');
+    }
+
+    $request = \Drupal::service('request_stack')->getCurrentRequest();
+
+    $this->setPageLimit();
+    $current_page = (int) $request->get('page', 0);
+    $max_page = ceil($this->getEntityCount() / $this->limit);
+
+    if ($current_page <= $max_page - 1) {
+      return NULL;
+    }
+
+    return Url::fromRoute('<current>', [], ['query' => [
+      'page' => max($max_page - 1, 0),
+      'limit' => $this->limit,
+    ]]);
+  }
+
+  /**
+   * Redirect to the specified page.
+   *
+   * @param \Drupal\Core\Url $url URL to redirect to.
+   * @return \Symfony\Component\HttpFoundation\RedirectResponse
+   */
+  public function redirectPage(Url $url): RedirectResponse {
+    return new RedirectResponse($url->toString());
   }
 
 }

--- a/web/modules/mof/src/PageLimitTrait.php
+++ b/web/modules/mof/src/PageLimitTrait.php
@@ -23,14 +23,9 @@ trait PageLimitTrait {
    * Returns a Url with new page number if there are not enough
    * entities to display on the current page. Returns NULL otherwise.
    *
-   * @throws \Exception If parent class doesn't implement getEntityCount().
    * @return \Drupal\Core\Url|null
    */
   public function getPageRedirectUrl(): ?Url {
-    if (!method_exists($this, 'getEntityCount')) {
-      throw new \Exception('getEntityCount() method does not exist');
-    }
-
     $request = \Drupal::service('request_stack')->getCurrentRequest();
 
     $this->setPageLimit();
@@ -55,6 +50,20 @@ trait PageLimitTrait {
    */
   public function redirectPage(Url $url): RedirectResponse {
     return new RedirectResponse($url->toString());
+  }
+
+  /**
+   * Count of total entites.
+   *
+   * @return int Number of entities.
+   */
+  protected function getEntityCount(): int {
+    return $this
+      ->getStorage()
+      ->getQuery()
+      ->accessCheck(TRUE)
+      ->count()
+      ->execute();
   }
 
 }


### PR DESCRIPTION
This fixes an issue in the model & license list builder where the current page number could exceed the valid range when items per page is set to a very high value. This ensures that the page number is adjusted correctly when the number of items per page exceeds the total number of models or licenses.

For example: Select 10 items per page, go to the last page, then select 1000.