### PR TITLE
Run update_models on push, adds paths filter

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,12 @@ on:
   push:
     branches:
       - main
+    paths:
+      - 'web/**'
+      - 'patches/**'
+      - 'scripts/**'
+      - 'composer.json'
+      - 'composer.lock'
   workflow_dispatch:
     inputs:
       environment:

--- a/.github/workflows/update_models.yml
+++ b/.github/workflows/update_models.yml
@@ -1,11 +1,11 @@
 name: Update models
 
 on:
-  pull_request:
-    types:
-      - closed
+  push:
     branches:
       - main
+    paths:
+      - 'models/**'
   workflow_dispatch:
     inputs:
       environment:
@@ -79,9 +79,8 @@ jobs:
       - name: Add server to known hosts
         run: ssh-keyscan -H $DEPLOY_HOST >> ~/.ssh/known_hosts
 
-      - name: List models on PR merge
-        if: ${{ github.event_name == 'pull_request' &&
-                github.event.pull_request.merged == true }}
+      - name: Check for model changes on push
+        if: ${{ github.event_name == 'push' }}
         run: |
           git fetch origin main
           git diff \
@@ -89,8 +88,8 @@ jobs:
             --diff-filter=AM origin/main...${{ github.sha }} | \
             grep '^models/.*\.yml$' > models.txt || true
 
-      - name: List models on workflow_dispatch
-        if: github.event_name == 'workflow_dispatch'
+      - name: Check for model changes on workflow_dispatch
+        if: ${{ github.event_name == 'workflow_dispatch' }}
         run: |
           git fetch origin ${{ github.ref_name }}
           mkdir tmp


### PR DESCRIPTION
This fine-tunes the workflows a bit more:

- Updated the `update_models` workflow to trigger on push events, which includes merges to the target branch.
- Added paths filter to ensure workflows trigger only when relevant files are changed during a push event.
