### PR TITLE
Add YAML Download link to Model view page

### DIFF
--- a/web/modules/mof/css/layout/model_evaluation.css
+++ b/web/modules/mof/css/layout/model_evaluation.css
@@ -12,21 +12,22 @@
   flex: 0 1 auto;
 }
 
-.json-download {
+.json-download, .yaml-download  {
   text-decoration: none;
+  margin-right: 10px;
 }
 
-.json-download:hover {
+.json-download:hover, .yaml-download:hover {
   text-decoration: underline;
 }
 
-.json-download:before {
+.json-download:before, .yaml-download:before {
   content: '\f019';
   font: var(--fa-font-solid);
   display: none;
 }
 
-.json-download svg {
+.json-download svg, .yaml-download svg {
   margin-right: 5px;
   vertical-align: inherit;
 }

--- a/web/modules/mof/src/Controller/ModelController.php
+++ b/web/modules/mof/src/Controller/ModelController.php
@@ -124,7 +124,7 @@ final class ModelController extends ControllerBase {
 
     $response = new Response();
     $response->setContent($yaml);
-    $response->headers->set('Content-Type', 'application/json');
+    $response->headers->set('Content-Type', 'application/yaml');
     $response->headers->set('Content-Length', (string)strlen($yaml));
     $response->headers->set('Content-Disposition', 'attachment; filename="mof.yml"');
 

--- a/web/modules/mof/src/Entity/Model.php
+++ b/web/modules/mof/src/Entity/Model.php
@@ -77,6 +77,7 @@ use Drupal\user\EntityOwnerTrait;
  *     "admin-collection" = "/admin/models",
  *     "delete-multiple-form" = "/admin/content/model/delete-multiple",
  *     "json" = "/model/{model}/json",
+ *     "yaml" = "/model/{model}/yaml",
  *   },
  *   field_ui_base_route = "entity.model.settings",
  * )

--- a/web/modules/mof/src/ModelViewBuilder.php
+++ b/web/modules/mof/src/ModelViewBuilder.php
@@ -111,6 +111,14 @@ class ModelViewBuilder extends EntityViewBuilder {
         '#attributes' => ['class' => ['model-link', 'json-download']],
       ];
 
+      $build['yaml'] = [
+        '#type' => 'link',
+        '#title' => $this->t('Download YAML'),
+        '#url' => $build['#model']->toUrl('yaml'),
+        '#weight' => -140,
+        '#attributes' => ['class' => ['model-link', 'yaml-download']],
+      ];
+
       $build['icons'] = [
         '#theme' => 'model_link',
         '#github' => $build['#model']->getGithubSlug(),


### PR DESCRIPTION
Model records can now be saved in YAML, this adds a link to the Model view page so that the user can use that functionality as an alternative to downloading the JSON version.