### PR TITLE
Implement MOF 1.1 relaxed requirements

### DIFF
--- a/web/modules/mof/config/install/mof.settings.yml
+++ b/web/modules/mof/config/install/mof.settings.yml
@@ -31,7 +31,7 @@ components:
     name: Model parameters (Final)
     description: "Trained model parameters, weights and biases"
     tooltip: "The license used for the final model parameters, 'License not specified', or 'Component not included'."
-    content_type: data
+    content_type: [data, code]
     class: 3
     weight: 10
     required: true
@@ -94,7 +94,7 @@ components:
     name: Evaluation results
     description: "The results from evaluating the model"
     tooltip: "The license used for evaluation results, 'License not specified', or 'Component not included'."
-    content_type: document
+    content_type: [document, code]
     class: 3
     weight: 101
     required: true
@@ -115,7 +115,7 @@ components:
     name: Model card
     description: "Model details including performance metrics, intended use, and limitations"
     tooltip: "The license used for the model card, 'License not specified', or 'Component not included'."
-    content_type: document
+    content_type: [document, code]
     class: 3
     weight: 70
     required: true
@@ -124,7 +124,7 @@ components:
     name: Data card
     description: "Documentation for datasets including source, characteristics, and preprocessing details"
     tooltip: "The license used for the data card, 'License not specified', or 'Component not included'."
-    content_type: document
+    content_type: [document, code]
     class: 3
     weight: 80
     required: true
@@ -133,7 +133,7 @@ components:
     name: Technical report
     description: "Technical report detailing capabilities and usage instructions for the model"
     tooltip: "The license used for the technical report, 'License not specified', or 'Component not included'."
-    content_type: document
+    content_type: [document, code]
     class: 3
     weight: 90
     required: true

--- a/web/modules/mof/src/ModelEvaluator.php
+++ b/web/modules/mof/src/ModelEvaluator.php
@@ -224,23 +224,21 @@ final class ModelEvaluator implements ModelEvaluatorInterface {
    *   An array of translatable strings.
    */
   public function getConditionalMessage(): array {
-    $licenses = $this->model->getLicenses();
-
     $messages = [
       $this->t('This model has an open source license on the following components, it should be using a type-appropriate license:'),
     ];
 
     $component_messages = [
-      $this->t('Model parameters (Final) of type data.'),
-      $this->t('Technical report of type documentation.'),
-      $this->t('Evaluation results of type documentation.'),
-      $this->t('Model card of type documentation.'),
-      $this->t('Data card of type documentation.'),
+      10 => $this->t('Model parameters (Final) of type data.'),
+      11 => $this->t('Technical report of type documentation.'),
+      12 => $this->t('Evaluation results of type documentation.'),
+      13 => $this->t('Model card of type documentation.'),
+      14 => $this->t('Data card of type documentation.'),
     ];
 
-    foreach (array_combine(self::CLASS_3_CIDS, $component_messages) as $cid => $message) {
-      if (isset($licenses[$cid]) && $this->licenseHandler->isOpenSource($licenses[$cid]['license'])) {
-        $messages[] = $message;
+    foreach (self::CLASS_3_CIDS as $cid) {
+      if (isset($component_messages[$cid]) && $this->isOpenSourceLicense($cid)) {
+        $messages[] = $component_messages[$cid];
       }
     }
 
@@ -252,21 +250,18 @@ final class ModelEvaluator implements ModelEvaluatorInterface {
    * @return bool
    */
   private function hasConditionalPass(): bool {
-    $licenses = $this->model->getLicenses();
-    $filtered = array_filter(self::CLASS_3_CIDS, fn($cid) => $this->isOpenSourceLicense($cid, $licenses));
-    return !empty($filtered);
+    $pass = array_filter(self::CLASS_3_CIDS, fn($cid) => $this->isOpenSourceLicense($cid));
+    return !empty($pass);
   }
 
   /**
    * Determine if a component is using an open source license.
    *
-   * @param int $cid
-   *   Component ID.
-   * @param array $licenses
-   *   Licenses for each component.
+   * @param int $cid Component ID.
    * @return bool
    */
-  private function isOpenSourceLicense(int $cid, array $licenses): bool {
+  private function isOpenSourceLicense(int $cid): bool {
+    $licenses = $this->model->getLicenses();
     return isset($licenses[$cid]) && $this->licenseHandler->isOpenSource($licenses[$cid]['license']);
   }
 

--- a/web/modules/mof/src/ModelEvaluator.php
+++ b/web/modules/mof/src/ModelEvaluator.php
@@ -146,13 +146,8 @@ final class ModelEvaluator implements ModelEvaluatorInterface {
     $in_progress = FALSE;
     for ($i = 3, $j = 3; $i >= 1; $i--, $j--) {
       $progress = $this->getProgress($i);
-
-      if ($evals[$i]['conditional'] === TRUE) {
-        $status = $this->t('Conditional');
-        $text_color = '#fff';
-        $background_color = '#4c1';
-      }
-      else if ($progress === 100.00) {
+      // under MOF 1.1 Conditional is a Pass
+      if ($progress === 100.00 || $evals[$i]['conditional'] === TRUE) {
         $status = $this->t('Qualified');
         $text_color = '#fff';
         $background_color = '#4c1';
@@ -211,12 +206,42 @@ final class ModelEvaluator implements ModelEvaluatorInterface {
   }
 
   /**
-   * Class 3 has a conditional pass if these components have an open source license.
+   * Class 3 has a conditional pass if these components have an open source license but we will
+   * inform the user that a type-appropriate license should be used.
    *  - `Model parameters (Final)` (10)
+   *  - `Technical report` (11)
+   *  - `Evaluation results` (12)
+   *  - `Model card` (13)
+   *  - `Data card` (14)
    */
+  public function getConditionalMessage(): string {
+    $licenses = $this->model->getLicenses();
+    $msg = 'This model has an open source license on the following components, it should be using a type-appropriate license:';
+    if (isset($licenses[10]) && $this->licenseHandler->isOpenSource($licenses[10]['license'])) {
+      $msg = $msg . '<br>' . '- Model parameters (Final) of type data.';
+    }
+    if (isset($licenses[11]) && $this->licenseHandler->isOpenSource($licenses[11]['license'])) {
+      $msg = $msg . '<br>' . '- Technical report of type documentation.';
+    }
+    if (isset($licenses[12]) && $this->licenseHandler->isOpenSource($licenses[12]['license'])) {
+      $msg = $msg . '<br>' . '- Evaluation results of type documentation.';
+    }
+    if (isset($licenses[13]) && $this->licenseHandler->isOpenSource($licenses[13]['license'])) {
+      $msg = $msg . '<br>' . '- Model card of type documentation.';
+    }
+    if (isset($licenses[14]) && $this->licenseHandler->isOpenSource($licenses[14]['license'])) {
+      $msg = $msg . '<br>' . '- Data card of type documentation.';
+    }
+    return $msg;
+  }
+
   private function hasConditionalPass(): bool {
     $licenses = $this->model->getLicenses();
-    return isset($licenses[10]) && $this->licenseHandler->isOpenSource($licenses[10]['license']);
+    return isset($licenses[10]) && $this->licenseHandler->isOpenSource($licenses[10]['license'])
+    || isset($licenses[11]) && $this->licenseHandler->isOpenSource($licenses[11]['license'])
+    || isset($licenses[12]) && $this->licenseHandler->isOpenSource($licenses[12]['license'])
+    || isset($licenses[13]) && $this->licenseHandler->isOpenSource($licenses[13]['license'])
+    || isset($licenses[14]) && $this->licenseHandler->isOpenSource($licenses[14]['license']);
   }
 
   /**

--- a/web/modules/mof/src/ModelViewBuilder.php
+++ b/web/modules/mof/src/ModelViewBuilder.php
@@ -152,7 +152,7 @@ class ModelViewBuilder extends EntityViewBuilder {
     }
 
     if ($evaluation[3]['conditional']) {
-      $this->messenger->addMessage($this->t('This model conditionally meets Class III because it has an open source license for Model Parameters (Final)'));
+      $this->messenger->addMessage($this->t($this->modelEvaluator->getConditionalMessage()));
     }
 
     if ($this->session->get('model_evaluation') === TRUE) {

--- a/web/modules/mof/src/ModelViewBuilder.php
+++ b/web/modules/mof/src/ModelViewBuilder.php
@@ -152,7 +152,19 @@ class ModelViewBuilder extends EntityViewBuilder {
     }
 
     if ($evaluation[3]['conditional']) {
-      $this->messenger->addMessage($this->t($this->modelEvaluator->getConditionalMessage()));
+      $list = [
+        '#theme' => 'item_list',
+        '#items' => [],
+      ];
+
+      $message = $this->modelEvaluator->getConditionalMessage();
+      $this->messenger->addMessage(array_shift($message));
+
+      foreach ($message as $_message) {
+        $list['#items'][] = $_message;
+      }
+
+      $this->messenger->addMessage($list);
     }
 
     if ($this->session->get('model_evaluation') === TRUE) {

--- a/web/modules/mof/src/ModelViewBuilder.php
+++ b/web/modules/mof/src/ModelViewBuilder.php
@@ -152,18 +152,12 @@ class ModelViewBuilder extends EntityViewBuilder {
     }
 
     if ($evaluation[3]['conditional']) {
-      $list = [
-        '#theme' => 'item_list',
-        '#items' => [],
-      ];
+      $list = ['#theme' => 'item_list', '#items' => []];
 
       $message = $this->modelEvaluator->getConditionalMessage();
       $this->messenger->addMessage(array_shift($message));
 
-      foreach ($message as $_message) {
-        $list['#items'][] = $_message;
-      }
-
+      $list['#items'] = $message;
       $this->messenger->addMessage($list);
     }
 


### PR DESCRIPTION
In MOF 1.1, the requirement to have a type-appropriate license on Class III components was relaxed from being a MUST to a SHOULD. This PR implements this change by allowing the selection of an open source code license on these Class III components.

As a result the Conditional flag is no longer displayed, instead the model is labeled as qualified for Class III, but the status message displayed at the top of the ModelView page is expanded to point out all the components for which there isn't a type-appropriate license.
