### PR TITLE
Add pointer to GitHub to model report page

### DIFF
--- a/web/profiles/mot_profile/config/install/webform.webform.report.yml
+++ b/web/profiles/mot_profile/config/install/webform.webform.report.yml
@@ -22,7 +22,7 @@ elements: |-
   report:
     '#type': textarea
     '#title': Report
-    '#description': 'Provide details on model inaccuracies'
+    '#description': 'Provide details on model inaccuracies. Alternatively you can <a href="https://github.com/lfai/model_openness_tool">submit a Pull Request or open an Issue on GitHub</a>.'
     '#autocomplete': ''
     '#required': true
     '#required_error': 'Report is required'


### PR DESCRIPTION
Since we now support updates to the models via GitHub it is worth pointing that out to the user as an alternative to submitting a report using the website form.
