### PR TITLE
Add CC-BY-SA (3 & 4) to selectable licenses

### DIFF
--- a/web/modules/mof/mof-licenses.json
+++ b/web/modules/mof/mof-licenses.json
@@ -373,7 +373,7 @@
          "isDeprecatedLicenseId":false,
          "detailsUrl":"https://spdx.org/licenses/CC-BY-SA-4.0.json",
          "referenceNumber":155,
-         "name":"Creative Commons Attribution 4.0 International",
+         "name":"Creative Commons Attribution Share Alike 4.0 International",
          "licenseId":"CC-BY-SA-4.0",
          "seeAlso":[
             "https://creativecommons.org/licenses/by-sa/4.0/legalcode"

--- a/web/modules/mof/mof-licenses.json
+++ b/web/modules/mof/mof-licenses.json
@@ -356,6 +356,33 @@
          "ContentType":"document"
       },
       {
+         "reference":"https://spdx.org/licenses/CC-BY-SA-3.0.html",
+         "isDeprecatedLicenseId":false,
+         "detailsUrl":"https://spdx.org/licenses/CC-BY-SA-3.0.json",
+         "referenceNumber":621,
+         "name":"Creative Commons Attribution Share Alike 3.0 Unported",
+         "licenseId":"CC-BY-SA-3.0",
+         "seeAlso": [
+           "https://creativecommons.org/licenses/by-sa/3.0/legalcode"
+         ],
+         "isOsiApproved": false,
+         "ContentType":"document"
+      },
+      {
+         "reference":"https://spdx.org/licenses/CC-BY-SA-4.0.html",
+         "isDeprecatedLicenseId":false,
+         "detailsUrl":"https://spdx.org/licenses/CC-BY-SA-4.0.json",
+         "referenceNumber":155,
+         "name":"Creative Commons Attribution 4.0 International",
+         "licenseId":"CC-BY-SA-4.0",
+         "seeAlso":[
+            "https://creativecommons.org/licenses/by-sa/4.0/legalcode"
+         ],
+         "isOsiApproved":false,
+         "isFsfLibre":true,
+         "ContentType":"document"
+      },
+      {
          "reference":"https://spdx.org/licenses/FreeBSD-DOC.html",
          "isDeprecatedLicenseId":false,
          "detailsUrl":"https://spdx.org/licenses/FreeBSD-DOC.json",


### PR DESCRIPTION
Adding the Creative Commons Attribution Share Alike License (CC-BY-SA), both version 3.0 unported and version 4.0, to the list of "document" type licenses that can be selected in the tool. This license (of either version) is used for datasets like [MusicBench from AMAAI Lab](https://huggingface.co/datasets/amaai-lab/MusicBench) and Arxiv papers like [Mustango's paper, also from AMAAI Lab](https://arxiv.org/abs/2311.08355).

Version 4.0 of the CC-BY-SA is compatible with the GPL version 3 or later, [on the condition that one specifies Creative Commons as proxy](https://www.gnu.org/licenses/license-list.html#ccbysa), and version 3.0 [is forwards-compatible, so it can be "upgraded" to verison 4.0 to become GPL-compatible](https://meta.stackoverflow.com/questions/271293/use-stack-overflow-answer-in-gpl-software-how-to-ask-for-permission).

The reason why I didn't include the Austrian, German, or other ports of the CC-BY-SA 3.0 is because I haven't seen them on HuggingFace.