### PR TITLE
Fixes bug in login/logout link when caching is enabled

### DIFF
--- a/web/modules/mof/src/Plugin/Menu/Oauth2LoginLogoutMenuLink.php
+++ b/web/modules/mof/src/Plugin/Menu/Oauth2LoginLogoutMenuLink.php
@@ -34,4 +34,11 @@ class Oauth2LoginLogoutMenuLink extends LoginLogoutMenuLink {
     }
   }
 
+  /**
+   * {@inheritdoc}
+   */
+  public function getCacheContexts() {
+    return [...parent::getCacheContexts(), 'user'];
+  }
+
 }


### PR DESCRIPTION
This fixes a menu caching bug that was introduced when we enabled caching for the API.  In certain cases the logout link would display the wrong user email address, leading to potential confusion about the logged-in user's identity despite correct authentication.