### PR TITLE
Update  DeepSeek V3/R1 papers' license

### DIFF
--- a/models/DeepSeek-R1.yml
+++ b/models/DeepSeek-R1.yml
@@ -106,7 +106,7 @@ release:
       name: 'Research paper'
       description: 'Research paper detailing the development and capabilities of the model'
       location: ''
-      license_name: 'License not specified'
+      license_name: arXiv.org perpetual non-exclusive license 1.0
       license_path: ''
     -
       name: 'Evaluation results'

--- a/models/DeepSeek-V3.yml
+++ b/models/DeepSeek-V3.yml
@@ -106,7 +106,7 @@ release:
       name: 'Research paper'
       description: 'Research paper detailing the development and capabilities of the model'
       location: ''
-      license_name: 'License not specified'
+      license_name: arXiv.org perpetual non-exclusive license 1.0
       license_path: ''
     -
       name: 'Evaluation results'


### PR DESCRIPTION
DeepSeek V3/R1 research papers are on the arxiv and the license is default to "[arXiv.org perpetual, non-exclusive license 1.0](https://arxiv.org/licenses/nonexclusive-distrib/1.0/)."

This license grants arXiv.org a perpetual, non-exclusive license to distribute the paper.