### PR TITLE
Fix label of invalid components

### DIFF
--- a/web/modules/mof/src/ModelViewBuilder.php
+++ b/web/modules/mof/src/ModelViewBuilder.php
@@ -217,13 +217,21 @@ class ModelViewBuilder extends EntityViewBuilder {
       return $build;
     }
 
-    $build = [
-      "{$status}_components" => [
-        '#theme' => 'item_list',
-        '#title' => $this->t('@status components', ['@status' => ucfirst($status)]),
-      ],
-    ];
-
+    if ($status == "invalid") {
+      $build = [
+        "{$status}_components" => [
+          '#theme' => 'item_list',
+          '#title' => $this->t('Components with an invalid license'),
+        ],
+      ];
+    } else {
+      $build = [
+        "{$status}_components" => [
+          '#theme' => 'item_list',
+          '#title' => $this->t('@status components', ['@status' => ucfirst($status)]),
+        ],
+      ];
+    }
     $components = array_filter(
       $this->modelComponents,
       fn($c) => in_array($c->id, $components));


### PR DESCRIPTION
The so called 'Invalid Components' in the Model View are really components with an invalid license.
This changes the label to be clearer what this list of components is.

This closes issue #71.