### PR TITLE
Fix conditional

### DIFF
--- a/web/modules/mof/src/BadgeGenerator.php
+++ b/web/modules/mof/src/BadgeGenerator.php
@@ -24,8 +24,8 @@ final class BadgeGenerator implements BadgeGeneratorInterface {
     for ($i = 3, $j = 3; $i >= 1; $i--, $j--) {
       $progress = $this->modelEvaluator->getProgress($i);
 
-      // under MOF 1.1 Conditional is a Pass
-      if ($progress === 100.00 || ($i === 3 && $evals[$i]['conditional'] === TRUE)) {
+      // Conditional is a Pass
+      if ($progress === 100.00 || ($i === 3 && $evals[$i]['conditional'] === TRUE && $evals[$i]['components']['missing'] == null)) {
         $status = $this->t('Qualified');
         $text_color = '#fff';
         $background_color = '#4c1';

--- a/web/modules/mof/src/ModelEvaluator.php
+++ b/web/modules/mof/src/ModelEvaluator.php
@@ -332,7 +332,7 @@ final class ModelEvaluator implements ModelEvaluatorInterface {
       return 0;
     }
 
-    if ($class === 3 && $evaluate[3]['conditional'] === true) {
+    if ($class === 3 && $evaluate[3]['conditional'] === true && $evaluate[3]['components']['missing'] == null) {
       return 100;
     }
 


### PR DESCRIPTION
This addresses issue #93 by enforcing that all required components for a given class are indeed included, even if they have a conditional pass because they don't have a type-appropriate license.

Warning: this kicks out most of the models currently labeled as class III out of class III. This shouldn't be deployed to production until the data is fixed.