### PR TITLE
Use the global license(s) as the default for components

### DIFF
--- a/web/modules/mof/src/Form/ModelEvaluateForm.php
+++ b/web/modules/mof/src/Form/ModelEvaluateForm.php
@@ -96,8 +96,8 @@ final class ModelEvaluateForm extends ModelForm {
    * {@inheritdoc}
    */
   public function save(array $form, FormStateInterface $form_state): int {
-    // We do not save the model when using `evaluate model` form.
-    // Models are only saved when using `submit model` form.
+    // Do not save the model when using `evaluate model` form.
+    // We instead provide a YAML download link in the model view builder.
     return 0;
   }
 

--- a/web/modules/mof/src/Form/ModelForm.php
+++ b/web/modules/mof/src/Form/ModelForm.php
@@ -132,6 +132,7 @@ abstract class ModelForm extends ContentEntityForm {
       '#description' => $this->t('Enter the name of the global/distribution-wide license (e.g. Apache-2.0).'),
       '#weight' => 1,
       '#attributes' => ['list' => 'license-datalist-0'],
+      '#placeholder' => $this->t('Begin typing to find a license'),
       '#default_value' => $model_licenses['global']['distribution']['name'] ?? '',
       '#states' => [
         'visible' => [
@@ -165,6 +166,7 @@ abstract class ModelForm extends ContentEntityForm {
       '#description' => $this->t('Enter the name of the code component license (e.g. Apache-2.0).'),
       '#weight' => 1,
       '#attributes' => ['list' => 'license-datalist-code'],
+      '#placeholder' => $this->t('Begin typing to find a license'),
       '#default_value' => $model_licenses['global']['code']['name'] ?? '',
       '#states' => [
         'visible' => [
@@ -198,6 +200,7 @@ abstract class ModelForm extends ContentEntityForm {
       '#description' => $this->t('Enter the name of the data component license (e.g. Apache-2.0).'),
       '#default_value' => $model_licenses['global']['data']['name'] ?? '',
       '#attributes' => ['list' => 'license-datalist-data'],
+      '#placeholder' => $this->t('Begin typing to find a license'),
       '#weight' => 1,
       '#states' => [
         'visible' => [
@@ -232,6 +235,7 @@ abstract class ModelForm extends ContentEntityForm {
       '#default_value' => $model_licenses['global']['document']['name'] ?? '',
       '#weight' => 1,
       '#attributes' => ['list' => 'license-datalist-document'],
+      '#placeholder' => $this->t('Begin typing to find a license'),
       '#states' => [
         'visible' => [
           ':input[name="license[document][included]"]' => ['checked' => true],

--- a/web/modules/mof/src/Form/ModelForm.php
+++ b/web/modules/mof/src/Form/ModelForm.php
@@ -322,6 +322,7 @@ abstract class ModelForm extends ContentEntityForm {
             '#description' => $this->t('The file system path to the component. (e.g. /path/to/component)'),
             '#default_value' => $model_licenses['components'][$cid]['component_path'] ?? '',
             '#placeholder' => $this->t('Enter file system path to the component'),
+            '#weight' => 100,
             '#attributes' => [
               'autocomplete' => 'off',
             ],
@@ -336,7 +337,7 @@ abstract class ModelForm extends ContentEntityForm {
           'global' => [
             '#type' => 'checkbox',
             '#parents' => ['global', $cid],
-            '#title' => $this->t('Does this component use the global license?'),
+            '#title' => $this->t('Check if this component uses a component-specific license'),
             '#default_value' => in_array($cid, $model_components) && empty($model_licenses['components'][$cid]) ? true : false,
             '#states' => [
               'visible' => [
@@ -368,7 +369,13 @@ abstract class ModelForm extends ContentEntityForm {
               'visible' => [
                 [
                   ":input[name=\"component[{$cid}]\"]" => ['checked' => true],
-                  ":input[name=\"global[{$cid}]\"]" => ['checked' => false],
+                  ":input[name=\"global[{$cid}]\"]" => ['checked' => true],
+                ],
+                'or',
+                [
+                  ":input[name=\"component[{$cid}]\"]" => ['checked' => true],
+                  ":input[name=\"license[distribution][included]\"]" => ['checked' => false],
+                  ":input[name=\"license[{$group}][included]\"]" => ['checked' => false],
                 ],
               ],
             ],
@@ -386,12 +393,18 @@ abstract class ModelForm extends ContentEntityForm {
               'visible' => [
                 [
                   ":input[name=\"component[{$cid}]\"]" => ['checked' => true],
-                  ":input[name=\"global[{$cid}]\"]" => ['checked' => false],
+                  ":input[name=\"global[{$cid}]\"]" => ['checked' => true],
+                ],
+                'or',
+                [
+                  ":input[name=\"component[{$cid}]\"]" => ['checked' => true],
+                  ":input[name=\"license[distribution][included]\"]" => ['checked' => false],
+                  ":input[name=\"license[{$group}][included]\"]" => ['checked' => false],
                 ],
               ],
             ],
           ],
-         ],
+        ],
       ];
     }
 

--- a/web/modules/mof/src/Form/ModelForm.php
+++ b/web/modules/mof/src/Form/ModelForm.php
@@ -440,55 +440,6 @@ abstract class ModelForm extends ContentEntityForm {
   }
 
   /**
-   * {@inheritdoc}
-   */
-  public function save(array $form, FormStateInterface $form_state): int {
-    $result = parent::save($form, $form_state);
-    return $result;
-
-    /*
-    try {
-      $status = $this
-        ->modelEvaluator
-        ->setModel($this->entity)
-        ->evaluate();
-
-      foreach ($status as $class => $missing_components) {
-        if (empty($missing_components)) {
-          $this
-            ->messenger()
-            ->addStatus($this->t('Model qualified for class @class', ['@class' => $class]));
-        }
-      }
-    }
-    catch (\Exception $e) {
-      $this->messenger()->addError($e->getMessage());
-    }
-
-    $logger_args = [
-      '%label' => $this->entity->label(),
-      'link' => $this->entity->toLink($this->t('View'))->toString(),
-    ];
-
-    switch ($result) {
-      case SAVED_NEW:
-        $this->logger('mof')->notice('New model (%label) has been created.', $logger_args);
-        break;
-
-      case SAVED_UPDATED:
-        $this->logger('mof')->notice('The model (%label) has been updated.', $logger_args);
-        break;
-
-      default:
-        throw new \LogicException('Could not save the model.');
-    }
-
-    $form_state->setRedirectUrl($this->entity->toUrl());
-    return $result;
-    */
-  }
-
-  /**
    * Build an HTML5 datalist for the specific content type or component.
    */
   final protected function buildDataList(int|string $type): array {


### PR DESCRIPTION
This PR addresses issue #94 by reversing the checkbox logic for each component that uses a specific license. Please test and confirm the changes.