### PR TITLE
Set component types to primary type

### DIFF
--- a/web/modules/mof/config/install/mof.settings.yml
+++ b/web/modules/mof/config/install/mof.settings.yml
@@ -4,7 +4,7 @@ components:
     name: Datasets
     description: "Training, validation and testing datasets used for the model"
     tooltip: "(Optional) The license used for the datasets, pretraining, fine-tuning, RLHF or otherwise, leave blank if the component is unlicensed."
-    content_type: [data, code, document]
+    content_type: data
     class: 1
     weight: 30
     required: true
@@ -31,7 +31,7 @@ components:
     name: Model parameters (Final)
     description: "Trained model parameters, weights and biases"
     tooltip: "The license used for the final model parameters. Leave blank if the component is unlicensed."
-    content_type: [data, code]
+    content_type: data
     class: 3
     weight: 10
     required: true
@@ -94,7 +94,7 @@ components:
     name: Evaluation results
     description: "The results from evaluating the model"
     tooltip: "The license used for evaluation results. Leave blank if the component is unlicensed."
-    content_type: [document, code]
+    content_type: document
     class: 3
     weight: 101
     required: true
@@ -112,7 +112,7 @@ components:
     name: Model card
     description: "Model details including performance metrics, intended use, and limitations"
     tooltip: "The license used for the model card. Leave blank if the component is unlicensed."
-    content_type: [document, code]
+    content_type: document
     class: 3
     weight: 70
     required: true
@@ -121,7 +121,7 @@ components:
     name: Data card
     description: "Documentation for datasets including source, characteristics, and preprocessing details"
     tooltip: "The license used for the data card. Leave blank if the component is unlicensed."
-    content_type: [document, code]
+    content_type: document
     class: 3
     weight: 80
     required: true
@@ -130,7 +130,7 @@ components:
     name: Technical report
     description: "Technical report detailing capabilities and usage instructions for the model"
     tooltip: "The license used for the technical report. Leave blank if the component is unlicensed."
-    content_type: [document, code]
+    content_type: document
     class: 3
     weight: 90
     required: true


### PR DESCRIPTION
Although some components can hold a mix bag of content, they all have a primary type which needs to be used for proper evaluation.