### PR TITLE
Conditional does not cover invalid licenses

### DIFF
--- a/web/modules/mof/src/BadgeGenerator.php
+++ b/web/modules/mof/src/BadgeGenerator.php
@@ -25,7 +25,7 @@ final class BadgeGenerator implements BadgeGeneratorInterface {
       $progress = $this->modelEvaluator->getProgress($i);
 
       // Conditional is a Pass
-      if ($progress === 100.00 || ($i === 3 && $evals[$i]['conditional'] === TRUE && $evals[$i]['components']['missing'] == null)) {
+      if ($progress === 100.00 || ($i === 3 && $evals[$i]['conditional'] === TRUE && $evals[$i]['components']['missing'] == null && $evals[$i]['components']['invalid'] == null)) {
         $status = $this->t('Qualified');
         $text_color = '#fff';
         $background_color = '#4c1';

--- a/web/modules/mof/src/ModelEvaluator.php
+++ b/web/modules/mof/src/ModelEvaluator.php
@@ -332,7 +332,7 @@ final class ModelEvaluator implements ModelEvaluatorInterface {
       return 0;
     }
 
-    if ($class === 3 && $evaluate[3]['conditional'] === true && $evaluate[3]['components']['missing'] == null) {
+    if ($class === 3 && $evaluate[3]['conditional'] === true && $evaluate[3]['components']['missing'] == null && $evaluate[3]['components']['invalid'] == null) {
       return 100;
     }
 


### PR DESCRIPTION
This fixes the evaluation process which must exclude invalid licenses.
Current behavior:
<img width="384" alt="image" src="https://github.com/user-attachments/assets/01b96e9a-7510-4ca9-b842-599c6bc5be20" />

With the fix:
<img width="378" alt="image" src="https://github.com/user-attachments/assets/fdb9db06-c512-4843-886f-b27da4bb029f" />
