### PR TITLE
Form and component clean up

### DIFF
--- a/web/modules/mof/src/Component.php
+++ b/web/modules/mof/src/Component.php
@@ -12,11 +12,9 @@ final class Component implements ComponentInterface {
 
   public readonly string $tooltip;
 
-  public readonly string|array $contentType;
+  public readonly string $contentType;
 
   public readonly int $class;
-
-  public readonly ?array $extraLicenses;
 
   public readonly int $weight;
 
@@ -30,41 +28,14 @@ final class Component implements ComponentInterface {
       $k = lcfirst(implode('', array_map('ucfirst', explode('_', $k))));
       if (property_exists($this, $k)) $this->$k = $v;
     }
-
-    if (!isset($this->extraLicenses)) {
-      $this->extraLicenses = NULL;
-    }
   }
 
   /**
-   * Get licenses for component.
+   * Get licenses for component type.
    */
   public function getLicenses(): array {
-    $licenses = [];
     $license_manager = \Drupal::service('license_handler');
-
-    if ($this->extraLicenses !== NULL) {
-      foreach ($this->extraLicenses as $extra) {
-        $licenses[] = ['licenseId' => $extra, 'name' => $extra];
-      } 
-    }
-
-    if (is_array($this->contentType)) {
-      foreach ($this->contentType as $type) {
-        $licenses = [
-          ...$licenses,
-          ...$license_manager->getLicensesByType($type)
-        ];
-      }
-    }
-    else {
-      $licenses = [
-        ...$licenses,
-        ...$license_manager->getLicensesByType($this->contentType)
-      ];
-    }
-
-    return array_unique($licenses, SORT_STRING);
+    return $license_manager->getLicensesByType($this->contentType);
   }
 
 }

--- a/web/modules/mof/src/LicenseHandler.php
+++ b/web/modules/mof/src/LicenseHandler.php
@@ -59,7 +59,7 @@ final class LicenseHandler implements LicenseHandlerInterface {
    *
    * @return array List of isFsfLibre licesnses.
    */
-  private function getFsfApproved(): array {
+  public function getFsfApproved(): array {
     return array_filter($this->licenses, fn($l) => $l->isFsfApproved());
   }
 


### PR DESCRIPTION
This PR refactors the Component and ModelForm classes. Since each component now supports only a single content_type, the logic for handling content_type as an array has been removed.