### PR TITLE
Fix edge case in GetProgress calculation

### DIFF
--- a/web/modules/mof/src/ModelEvaluator.php
+++ b/web/modules/mof/src/ModelEvaluator.php
@@ -326,11 +326,13 @@ final class ModelEvaluator implements ModelEvaluatorInterface {
       return 0;
     }
 
-    // The tech report can be omitted if the research paper is provided which
+    // The tech report (cid 11) MAY be omitted if a research paper (cid 21) is provided which
     // means that for Class 1 we have one fewer required component
     // (and not for classes 2 and 3 where either the tech report or the research paper is counted)
-    if ($class == 1) $total--;
-
+    if ($class == 1 && ! array_search(11, $evaluate[1]['components']['included'])
+        && array_search(21, $evaluate[1]['components']['included'])) {
+        $total--;
+    }
     $progress = ($included / $total) * 100;
 
     // In case both the tech report and the research paper are provided we end up with more than


### PR DESCRIPTION
Fixes another edge case: the current progress calculation blindly decreases the total number of required components by 1 to account for the tech report being optional if the paper is provided. As a result when both are provided if another component is missing it doesn't get noticed:

<img width="362" alt="image" src="https://github.com/user-attachments/assets/c4bb8487-5353-4a4c-b770-cbbdcd9c9d08" />

The fix is to decrease the number of required component only in the case where the tech report is not provided and the paper is.

<img width="359" alt="image" src="https://github.com/user-attachments/assets/3333216a-92d7-4b23-933e-bb55be1d7ef1" />
