### PR TITLE
Add DCO and related instructions to the Contributions doc

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,3 +66,22 @@ To submit bug fixes and improvements to the MOT software please follow these ste
 Note that all changes to the code should carry a sign-off.
 
 See the [INSTALL.md](INSTALL.md) file for more information on how to setup your environment to run MOT.
+
+## Legal stuff
+
+To handle the legal aspects of contributions, we use the `Developer's
+Certificate of Origin 1.1 (DCO)](DCO1.1.txt) approach like many other
+open source projects use nowadays.
+
+We simply ask that when you submit a patch for review, you include a
+sign-off statement in the commit message.
+
+Here is an example Signed-off-by line, which indicates that the
+submitter accepts the DCO:
+
+::
+
+    Signed-off-by: John Doe <john.doe@example.com>
+
+You can include this automatically when you commit a change to your
+local git repository using ``git commit -s``.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,9 +79,9 @@ sign-off statement in the commit message.
 Here is an example Signed-off-by line, which indicates that the
 submitter accepts the DCO:
 
-::
-
-    Signed-off-by: John Doe <john.doe@example.com>
+   ```
+   Signed-off-by: John Doe <john.doe@example.com>
+   ```
 
 You can include this automatically when you commit a change to your
 local git repository using ``git commit -s``.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,7 +69,7 @@ See the [INSTALL.md](INSTALL.md) file for more information on how to setup your 
 
 ## Legal stuff
 
-To handle the legal aspects of contributions, we use the `Developer's
+To handle the legal aspects of contributions, we use the [Developer's
 Certificate of Origin 1.1 (DCO)](DCO1.1.txt) approach like many other
 open source projects use nowadays.
 

--- a/DCO1.1.txt
+++ b/DCO1.1.txt
@@ -1,0 +1,25 @@
+Developer's Certificate of Origin 1.1
+
+       By making a contribution to this project, I certify that:
+
+       (a) The contribution was created in whole or in part by me and I
+           have the right to submit it under the open source license
+           indicated in the file; or
+
+       (b) The contribution is based upon previous work that, to the best
+           of my knowledge, is covered under an appropriate open source
+           license and I have the right under that license to submit that
+           work with modifications, whether created in whole or in part
+           by me, under the same open source license (unless I am
+           permitted to submit under a different license), as indicated
+           in the file; or
+
+       (c) The contribution was provided directly to me by some other
+           person who certified (a), (b) or (c) and I have not modified
+           it.
+
+       (d) I understand and agree that this project and the contribution
+           are public and that a record of the contribution (including all
+           personal information I submit with it, including my sign-off) is
+           maintained indefinitely and may be redistributed consistent with
+           this project or the open source license(s) involved.


### PR DESCRIPTION
In line with many open source projects our repo now requires a signoff on contributions. This adds the related info to our contributions doc.