### PR TITLE
Enable public access to license collection - resolves #131

### DIFF
--- a/web/modules/mof/mof.links.action.yml
+++ b/web/modules/mof/mof.links.action.yml
@@ -14,7 +14,7 @@ entity.license.add:
   route_name: entity.license.add_form
   title: 'Add license'
   appears_on:
-    - entity.license.collection
+    - entity.license.admin_collection
 
 entity.model.community_preferred:
   route_name: entity.model.add_form

--- a/web/modules/mof/mof.links.menu.yml
+++ b/web/modules/mof/mof.links.menu.yml
@@ -11,6 +11,13 @@ entity.model.models:
   menu_name: main
   weight: 0
 
+entity.license.models:
+  title: 'Licenses'
+  description: 'List licenses'
+  route_name: entity.license.collection
+  menu_name: main
+  weight: 2
+
 entity.model.evaluate_model:
   title: 'Evaluate Model'
   description: 'Evaluate your model'

--- a/web/modules/mof/mof.links.task.yml
+++ b/web/modules/mof/mof.links.task.yml
@@ -37,5 +37,5 @@ entity.model.admin_collection:
 
 entity.license.collection:
   title: 'Licenses'
-  route_name: entity.license.collection
+  route_name: entity.license.admin_collection
   base_route: entity.model.admin_collection

--- a/web/modules/mof/mof.permissions.yml
+++ b/web/modules/mof/mof.permissions.yml
@@ -2,8 +2,13 @@ administer model:
   title: 'Administer models'
   restrict access: true
 
+view licenses:
+  title: 'View licenses'
+  description: 'Allow users to view licenses.'
+
 administer licenses:
   title: 'Administer licenses'
+  description: 'Allow users to administer licenses.'
   restrict access: true
 
 view model collection:

--- a/web/modules/mof/mof.routing.yml
+++ b/web/modules/mof/mof.routing.yml
@@ -115,3 +115,19 @@ mof.model_badge:
   requirements:
     _entity_access: model.view
     class: '1|2|3'
+
+entity.license.collection:
+  path: '/licenses'
+  defaults:
+    _entity_list: 'license'
+    _title: 'Licenses'
+  requirements:
+    _permission: 'view licenses'
+
+entity.license.admin_collection:
+  path: '/admin/licenses'
+  defaults:
+    _entity_list: 'license'
+    _title: 'License Administration'
+  requirements:
+    _permission: 'administer licenses'    

--- a/web/modules/mof/src/Entity/License.php
+++ b/web/modules/mof/src/Entity/License.php
@@ -43,7 +43,8 @@ use Drupal\mof\LicenseInterface;
  *     "uuid" = "uuid",
  *   },
  *   links = {
- *     "collection" = "/admin/licenses",
+ *     "collection" = "/licenses",
+ *     "admin-collection" = "/admin/licenses",
  *     "add-form" = "/admin/license/add",
  *     "edit-form" = "/admin/license/{license}/edit",
  *     "delete-form" = "/admin/license/{license}/delete",

--- a/web/modules/mof/src/LicenseListBuilder.php
+++ b/web/modules/mof/src/LicenseListBuilder.php
@@ -20,7 +20,7 @@ final class LicenseListBuilder extends EntityListBuilder {
    * {@inheritdoc}
    */
   public function buildHeader(): array {
-    return [
+    $header = [
       'name' => [
         'data' => $this->t('Name'),
         'field' => 'name',
@@ -31,17 +31,31 @@ final class LicenseListBuilder extends EntityListBuilder {
         'field' => 'license_id',
         'specifier' => 'license_id',
       ],
-    ] + parent::buildHeader();
+    ];
+
+    // Conditionally add the Operations column header for users with the administer licenses permission.
+    if (\Drupal::currentUser()->hasPermission('administer licenses')) {
+      $header += parent::buildHeader();
+    }
+
+    return $header;
   }
 
   /**
    * {@inheritdoc}
    */
   public function buildRow(EntityInterface $entity): array {
-    return [
+    $row = [
       'name' => $entity->getName(),
       'license_id' => $entity->getLicenseId(),
-    ] + parent::buildRow($entity);
+    ];
+
+    // Conditionally add the Operations column rows for users with the administer licenses permission.
+    if (\Drupal::currentUser()->hasPermission('administer licenses')) {
+      $row += parent::buildRow($entity);
+    }
+
+    return $row;
   }
 
   /**
@@ -72,4 +86,3 @@ final class LicenseListBuilder extends EntityListBuilder {
   }
 
 }
-

--- a/web/profiles/mot_profile/config/install/user.role.anonymous.yml
+++ b/web/profiles/mot_profile/config/install/user.role.anonymous.yml
@@ -14,3 +14,4 @@ is_admin: false
 permissions:
   - 'access content'
   - 'view model collection'
+  - 'view licenses'


### PR DESCRIPTION
This set of changes:
- Creates a new `view licenses` permission and assigns it to the anonymous user
- Creates a new route for `/licenses` which uses the new permission
- Removes certain editing features from the public Licenses view