### PR TITLE
Add OpenMDW license and change Apache 2.0 to code+document

### DIFF
--- a/web/modules/mof/mof-licenses.json
+++ b/web/modules/mof/mof-licenses.json
@@ -130,7 +130,7 @@
          ],
          "isOsiApproved":true,
          "isFsfLibre":true,
-         "ContentType":"code"
+         "ContentType":["code","document"]
       },
       {
          "reference":"https://spdx.org/licenses/ECL-1.0.html",
@@ -421,6 +421,20 @@
          "isOsiApproved":false,
          "isFsfLibre":true,
          "ContentType":"document"
+      },
+      {
+         "reference":"https://openmdw.ai/license/",
+         "isDeprecatedLicenseId":false,
+         "detailsUrl":"https://openmdw.ai",
+         "referenceNumber":999,
+         "name":"OpenMDW v1.0",
+         "licenseId":"OpenMDW-1.0",
+         "seeAlso":[
+            "https://openmdw.ai"
+         ],
+         "isOsiApproved":true,
+         "isFsfLibre":false,
+         "ContentType":["document","data","code"]
       }
    ],
    "releaseDate":"2024-03-25"

--- a/web/modules/mof/src/LicenseHandler.php
+++ b/web/modules/mof/src/LicenseHandler.php
@@ -142,5 +142,37 @@ final class LicenseHandler implements LicenseHandlerInterface {
     return in_array($license, self::OPEN_DATA_LICENSES);
   }
 
-}
+  /**
+   * Determine if a license is an open source license.
+   *
+   * @param string $license
+   *   The license name.
+   *
+   * @return bool
+   *   TRUE if license is open-source.
+   *   FALSE otherwise.
+   */
+  public function isOpenSourceLicense(string $license): bool {
+    return $this->isFsfApproved($license)
+      || $this->isOpenData($license)
+      || $this->isOsiApproved($license);
+  }
 
+  /**
+   * Check if a license is appropriate for the given component type.
+   *
+   * Get type-appropriate license arrays and checks if the provided license ID exists among them.
+   *
+   * @param string $license
+   *   The license ID to check (e.g., 'MIT').
+   *
+   * @param string $type
+   *   The component's content type (i.e., 'code', 'data', or 'document').
+   *
+   * @return bool
+   *   TRUE if the license ID is type-specific, FALSE otherwise.
+   */
+  public function isTypeAppropriate(string $license, string $type): bool {
+    return in_array($license, array_map('strval', $this->getLicensesByType($type)));
+  }
+}

--- a/web/modules/mof/src/ModelEvaluator.php
+++ b/web/modules/mof/src/ModelEvaluator.php
@@ -145,8 +145,8 @@ final class ModelEvaluator implements ModelEvaluatorInterface {
       $type = $component->contentType;
 
       // Does the component have a type-appropriate license? and is it open?
-      $type_appropriate = $this->isTypeAppropriate($license, $type);
-      $is_open = $this->isOpenSourceLicense($license);
+      $type_appropriate = $this->licenseHandler->isTypeAppropriate($license, $type);
+      $is_open = $this->licenseHandler->isOpenSourceLicense($license);
 
       if ($type_appropriate && $is_open) {
         $evaluation[$class]['components'][$status][] = $cid;
@@ -165,24 +165,6 @@ final class ModelEvaluator implements ModelEvaluatorInterface {
       }
       $evaluation[$class]['licenses'][$cid] = $license;
     }
-  }
-
-  /**
-   * Check if a license is appropriate for the given component type.
-   *
-   * Get type-appropriate license arrays and checks if the provided license ID exists among them.
-   *
-   * @param string $license
-   *   The license ID to check (e.g., 'MIT').
-   *
-   * @param string $type
-   *   The component's content type (i.e., 'code', 'data', or 'document').
-   *
-   * @return bool
-   *   TRUE if the license ID is type-specific, FALSE otherwise.
-   */
-  private function isTypeAppropriate(string $license, string $type): bool {
-    return in_array($license, array_map('strval', $this->licenseHandler->getLicensesByType($type)));
   }
 
   /**
@@ -306,22 +288,6 @@ final class ModelEvaluator implements ModelEvaluatorInterface {
     }
 
     return $messages;
-  }
-
-  /**
-   * Determine if a license is an open source license.
-   *
-   * @param string $license
-   *   The license name.
-   *
-   * @return bool
-   *   TRUE if license is open-source.
-   *   FALSE otherwise.
-   */
-  private function isOpenSourceLicense(string $license): bool {
-    return $this->licenseHandler->isFsfApproved($license)
-      || $this->licenseHandler->isOpenData($license)
-      || $this->licenseHandler->isOsiApproved($license);
   }
 
   /**


### PR DESCRIPTION
OpenMDW is added to mof-licenses.json with a bogus reference number and (prematurely) declared OSI approved to be processed accordingly. The license files should really be refactored to be more flexible.

Also moved a couple of license related functions from ModelEvaluator to LicenseHandler where they belong.

This resolves issue #132.