### PR TITLE
Add filter form to license lists - resolves #147

### DIFF
--- a/web/modules/mof/src/Form/LicenseSearchForm.php
+++ b/web/modules/mof/src/Form/LicenseSearchForm.php
@@ -1,0 +1,106 @@
+<?php declare(strict_types=1);
+
+namespace Drupal\mof\Form;
+
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Form\FormBase;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpFoundation\Request;
+
+final class LicenseSearchForm extends FormBase {
+
+  private readonly Request $request;
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    $form = new static();
+    $form->request = $container->get('request_stack')->getCurrentRequest();
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId() {
+    return 'license_search_form';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state) {
+    $req = $this->request;
+
+    $form['search'] = [
+      '#type' => 'details',
+      '#title' => $this->t('Search filters'),
+      '#open' => $req->get('name') || $req->get('license_id') ? TRUE : FALSE,
+    ];
+
+    $form['search']['name'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Name'),
+      '#default_value' => $req->get('name') ?? '',
+    ];
+
+    $form['search']['license_id'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('License ID'),
+      '#default_value' => $req->get('license_id') ?? '',
+    ];
+
+    $form['search']['actions']['wrapper'] = [
+      '#type' => 'container',
+    ];
+
+    $form['search']['actions']['wrapper']['submit'] = [
+      '#type' => 'submit',
+      '#value' => $this->t('Search'),
+    ];
+
+    if ($req->getQueryString()) {
+      $form['search']['actions']['wrapper']['reset'] = [
+        '#type' => 'submit',
+        '#value' => $this->t('Reset'),
+        '#submit' => ['::resetForm'],
+      ];
+    }
+
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+    $query = $this->request->query->all();
+
+    $name = $form_state->getValue('name') ?? FALSE;
+    if ($name) {
+      $query['name'] = $name;
+    }
+    else if (isset($query['name']) && !$name) {
+      unset($query['name']);
+    }
+
+    $license_id = $form_state->getValue('license_id') ?? FALSE;
+    if ($license_id) {
+      $query['license_id'] = $license_id;
+    }
+    else if (isset($query['license_id']) && !$license_id) {
+      unset($query['license_id']);
+    }
+
+    $form_state->setRedirect($this->request->attributes->get('_route'), $query);
+  }
+
+  /**
+   * Reset the form.
+   */
+  public function resetForm(array $form, FormStateInterface $form_state) {
+    $form_state->setRedirect($this->request->attributes->get('_route'));
+  }
+
+}

--- a/web/modules/mof/src/LicenseListBuilder.php
+++ b/web/modules/mof/src/LicenseListBuilder.php
@@ -1,13 +1,17 @@
 <?php
-
 declare(strict_types=1);
 
 namespace Drupal\mof;
 
-use Drupal\Core\Entity\EntityListBuilder;
 use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Entity\EntityListBuilder;
+use Drupal\Core\Entity\EntityStorageInterface;
+use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Entity\Query\QueryInterface;
+use Drupal\Core\Form\FormBuilderInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
 
 /**
  * Provides a list controller for the license entity type.
@@ -15,6 +19,33 @@ use Symfony\Component\HttpFoundation\RedirectResponse;
 final class LicenseListBuilder extends EntityListBuilder {
 
   use PageLimitTrait;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function __construct(
+    EntityTypeInterface $entity_type,
+    EntityStorageInterface $storage,
+    private readonly FormBuilderInterface $formBuilder,
+    private readonly Request $request
+  ) {
+    parent::__construct($entity_type, $storage);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function createInstance(
+    ContainerInterface $container,
+    EntityTypeInterface $entity_type
+  ) {
+    return new static(
+      $entity_type,
+      $container->get('entity_type.manager')->getStorage($entity_type->id()),
+      $container->get('form_builder'),
+      $container->get('request_stack')->getCurrentRequest()
+    );
+  }
 
   /**
    * {@inheritdoc}
@@ -71,6 +102,16 @@ final class LicenseListBuilder extends EntityListBuilder {
       ->accessCheck(TRUE)
       ->tableSort($header);
 
+    if ($name = $this->request->get('name')) {
+      $name = addcslashes($name, '\\%_');
+      $query->condition('name', "%{$name}%", 'LIKE');
+    }
+
+    if ($license_id = $this->request->get('license_id')) {
+      $license_id = addcslashes($license_id, '\\%_');
+      $query->condition('license_id', "%{$license_id}%", 'LIKE');
+    }
+
     if ($this->limit) {
       $query->pager($this->limit);
     }
@@ -82,7 +123,30 @@ final class LicenseListBuilder extends EntityListBuilder {
    * {@inheritdoc}
    */
   public function render(): array|RedirectResponse {
-    return ($url = $this->getPageRedirectUrl()) != NULL ? $this->redirectPage($url) : parent::render();
+    if (($url = $this->getPageRedirectUrl()) !== NULL) {
+      return $this->redirectPage($url);
+    }
+
+    $build = parent::render();
+    $build['#attached']['library'][] = 'mof/license-list';
+    $build['search'] = $this->formBuilder->getForm('\Drupal\mof\Form\LicenseSearchForm');
+    $build['search']['#weight'] = -100;
+    $build['table']['#attributes']['class'][] = 'tablesaw';
+    $build['table']['#attributes']['class'][] = 'tablesaw-stack';
+    $build['table']['#attributes']['data-tablesaw-mode'] = 'stack';
+
+    $build['#cache'] = [
+      'contexts' => [
+        'url.query_args:name',
+        'url.query_args:license_id',
+        'url.query_args:page',
+        'url.query_args:limit',
+        'url.query_args:sort',
+        'url.query_args:order',
+      ],
+    ];
+
+    return $build;
   }
 
 }


### PR DESCRIPTION
- Adds `LicenseSearchForm` to enable license list filtering by `name` and `license_id`
- Implements form processing in `LicenseListBuilder`