### PR TITLE
Nonreg test

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,6 +72,8 @@ Note that all changes to the code should carry a sign-off.
 
 See the [INSTALL.md](INSTALL.md) file for more information on how to setup your environment to run MOT.
 
+Before submitting any PR, please, verify that your changes do not have any unexpected side effects using the [non-regression tests](Test_Scripts/README.md#non-regression-tests).
+
 ## Legal stuff
 
 To handle the legal aspects of contributions, like many other

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,7 +72,7 @@ Note that all changes to the code should carry a sign-off.
 
 See the [INSTALL.md](INSTALL.md) file for more information on how to setup your environment to run MOT.
 
-Before submitting any PR, please, verify that your changes do not have any unexpected side effects using the [non-regression tests](Test_Scripts/README.md#non-regression-tests).
+Before submitting any PR, please, verify that your changes do not have any unexpected side effects using the [non-regression tests](Test_Data/README.md#non-regression-tests).
 
 ## Legal stuff
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,7 +57,7 @@ instructions on their respective websites:
   Note: make sure you have created a `.env` file, you can use the below command to create an empty `.env` file.
   ```shell
    touch .env
-```
+  ```
 
 ## Contributing to the MOT software
 

--- a/Test_Data/README.md
+++ b/Test_Data/README.md
@@ -19,3 +19,10 @@ Additionally, there is a script called `update_license_yml_files.py` that can be
 
 The script `update_license_yml_files.py` can be run with the following command: `python update_license_yml_files.py <license_json_file> <mof_license_json_file>`
 
+## Non-regression tests
+
+There are two simple non-regression tests you can use to check that changes to the MOT code have not broken any of the existing functionality:
+
+1. `runtest.sh` is a simple bash script which downloads, using the MOT REST API, all the data from a local instance of the MOT, in which the Test data this directory contains was loaded, and verifies that the output is identical to the reference output file `test_setup_results.json`.
+
+2. `nonregression_test_setup.sh` & `nonregression_test_check.sh`. The former is a script that downloads all the data from a local instance of the MOT and generates a reference output file called `test_setup_results.json`. This should be run before any changes to the code are made. Then, the script `nonregression_test_check.sh` can be run to test that the results have not changed since the last time the setup was done.

--- a/Test_Data/Test_Scripts/nonregression_test_check.sh
+++ b/Test_Data/Test_Scripts/nonregression_test_check.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# This script is used to run a simple non-regression test against a local instance of the MOT.
+# This is the second part of the test. This part downloads, using the REST API, the models
+# that are in the database into a file and checks that it is identical to the test reference file.
+# This only works after the first part, nonregression_test_setup.sh has been run.
+
+if [ ! -f test_setup_results.json ]
+then echo "Error: test_setup_results.json not found" && exit 1
+fi
+
+# we exclude date fields that are volatile
+curl -o - http://127.0.0.1:8888/api/v1/models | jq | grep -v date > results.json
+
+diff -q results.json test_setup_results.json
+if [ $? -ne 0 ] ; then
+  echo 'Test failed'
+  exit 1
+fi
+echo 'Test passed'
+exit 0

--- a/Test_Data/Test_Scripts/nonregression_test_setup.sh
+++ b/Test_Data/Test_Scripts/nonregression_test_setup.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# This script is used to run a simple non-regression test against a local instance of MOT.
+# This is the first part, and it simply downloads, using the REST API, the models that are in
+# the database into a file that can be checked against later on.
+# This should be run before any changes are made. Once changes have been made, simply run the
+# second part nonregression_test_check.sh to check that the changes have not broken anything.
+
+# we exclude date fields that are volatile
+curl -o - http://127.0.0.1:8888/api/v1/models | jq | grep -v date > test_setup_results.json


### PR DESCRIPTION
This adds a simple pair of bash scripts that can be used to test for non-regression when making changes to the MOT software.
This test doesn't pretend to be exhaustive. For one thing, it heavily depends on the REST API, which if broken or incomplete may hide some undesired changes.
This is however better than nothing!
