### PR TITLE
Hide model description field

### DIFF
--- a/web/modules/mof/src/Entity/Model.php
+++ b/web/modules/mof/src/Entity/Model.php
@@ -355,6 +355,10 @@ final class Model extends RevisionableContentEntityBase implements ModelInterfac
         'label' => 'above',
         'weight' => -90,
       ])
+      // The description field is not currently saved in the YAML model file so we may as well hide it away
+      // until we decide whether to just get rid of it altogether or add it to the YAML file.
+      ->setDisplayOptions('view', ['region' => 'hidden'])
+      ->setDisplayOptions('form', ['region' => 'hidden'])
       ->setDisplayConfigurable('view', TRUE)
       ->setRequired(FALSE);
 


### PR DESCRIPTION
As a stopgap solution to issue #173, this hides from the Evaluate and Edit forms the model description field which isn't saved in the model YAML file,.